### PR TITLE
WIP: Improve type safety and explicitness in config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -208,3 +208,5 @@ tests/results/
 # Generated version file
 src/uQCme/_version.py
 output/
+
+/TODO.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking Changes
+
+- Data input YAML no longer accepts scalar file paths. Use the structured
+  form instead:
+  ```yaml
+  data:
+    file: "run_data.tsv"
+  ```
+  instead of:
+  ```yaml
+  data: "run_data.tsv"
+  ```
+- Empty strings in data input fields are now treated as explicit configured
+  values, not as absent values. Older placeholder configs that set multiple
+  data fields to `""`, such as both `file: ""` and `api_call: ""`, now fail
+  validation because they configure multiple data sources.
+- Unknown keys under `data` are now rejected. Data input config only accepts
+  the supported keys: `file`, `api_call`, `api_query_params`,
+  `api_bearer_token`, `api_bearer_token_env`, and `api_headers`.
+- `qc.input.data` is now required in YAML. A QC config must explicitly provide
+  either `data.file` or `data.api_call`.
+
 ### Added
 
 - `uqcme-dashboard-smoke` console command for starting a dashboard process,

--- a/pixi.toml
+++ b/pixi.toml
@@ -3,7 +3,7 @@ authors = ["Kim Ng <kimleeng@gmail.com>"]
 channels = ["conda-forge", "bioconda"]
 name = "uQCme"
 platforms = ["linux-64", "osx-arm64", "osx-64"]
-version = "0.9.2"
+version = "0.10.0"
 
 [tasks]
 build = "rattler-build build --recipe recipe.yaml"

--- a/src/uQCme/__init__.py
+++ b/src/uQCme/__init__.py
@@ -1,5 +1,5 @@
 """uQCme - Microbial Quality Control Dashboard"""
 
-__version__ = "0.9.2"
+__version__ = "0.10.0"
 __description__ = "Microbial Quality Control Dashboard"
 __author__ = "SSI-DK"

--- a/src/uQCme/app/main.py
+++ b/src/uQCme/app/main.py
@@ -12,31 +12,41 @@ Note: This module requires the 'app' or 'all' extras to be installed:
 
 import os
 import sys
-import streamlit as st
-from streamlit.web import cli as stcli
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Union
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
 import pandas as pd
 import requests
+import streamlit as st
 import yaml
-from pathlib import Path
-from typing import Dict, Any, List, Optional, Union
-from urllib.parse import urlencode, urlparse, urlunparse, parse_qs
+from streamlit.web import cli as stcli
+
 from uQCme.app.plot import (
     QCPlotter,
     build_quality_metric_catalog,
     get_plottable_quality_metric_columns,
 )
-from uQCme.core.loader import (
-    collect_duplicate_row_warnings,
-    get_unique_columns_from_mapping,
-    _resolve_api_bearer_token,
-    load_config_from_file,
-    load_data_from_config,
-    load_data_from_api_with_debug,
-    prepare_loaded_data_frame,
+from uQCme.core.config import (
+    APIDataSource,
+    DataInput,
+    RawDataInput,
+    SampleApiAction,
+    TSVDataSource,
+    UQCMeConfig,
+    normalize_data_input,
 )
 from uQCme.core.engine import QCProcessor
-from uQCme.core.config import UQCMeConfig, DataInput, SampleApiAction
 from uQCme.core.exceptions import ConfigError, DataLoadError, ValidationError
+from uQCme.core.loader import (
+    _resolve_api_bearer_token,
+    collect_duplicate_row_warnings,
+    get_unique_columns_from_mapping,
+    load_config_from_file,
+    load_data_from_api_with_debug,
+    load_data_from_config,
+    prepare_loaded_data_frame,
+)
 
 
 class QCDashboard:
@@ -69,77 +79,47 @@ class QCDashboard:
             return False
         return bool(self.config.app.dashboard.debug_api)
 
-    def _resolve_data_config_for_runtime(
-        self, data_config: Union[str, DataInput, Dict[str, Any]]
-    ) -> Union[str, DataInput, Dict[str, Any]]:
+    def _resolve_data_config_for_runtime(self, data_config: RawDataInput) -> DataInput:
         """Resolve runtime data config, including forwarded query params."""
-        resolved_data_config = data_config
+        resolved_data_config = normalize_data_input(data_config)
+        source = resolved_data_config.source
 
-        if isinstance(resolved_data_config, DataInput):
-            api_query_params = resolved_data_config.api_query_params
-            if resolved_data_config.api_call and api_query_params:
-                dynamic_url = self._build_api_url_with_query_params(
-                    resolved_data_config.api_call, api_query_params
+        if isinstance(source, APIDataSource) and source.query_params:
+            dynamic_url = self._build_api_url_with_query_params(
+                source.call, source.query_params
+            )
+            return DataInput(
+                source=APIDataSource(
+                    call=dynamic_url,
+                    query_params=source.query_params,
+                    bearer_token=source.bearer_token,
+                    headers=source.headers,
                 )
-                resolved_data_config = DataInput(
-                    file=resolved_data_config.file,
-                    api_call=dynamic_url,
-                    api_query_params=api_query_params,
-                    api_bearer_token=resolved_data_config.api_bearer_token,
-                    api_bearer_token_env=(resolved_data_config.api_bearer_token_env),
-                    api_headers=resolved_data_config.api_headers,
-                )
-        elif isinstance(resolved_data_config, dict) and resolved_data_config.get(
-            "api_call"
-        ):
-            api_query_params = resolved_data_config.get("api_query_params")
-            if api_query_params:
-                dynamic_url = self._build_api_url_with_query_params(
-                    resolved_data_config["api_call"], api_query_params
-                )
-                resolved_data_config = {**resolved_data_config, "api_call": dynamic_url}
+            )
 
         return resolved_data_config
 
-    def _is_api_data_config(
-        self, data_config: Union[str, DataInput, Dict[str, Any]]
-    ) -> bool:
+    def _is_api_data_input(self, data_input: DataInput) -> bool:
         """Return True when the runtime data source is API-based."""
-        if isinstance(data_config, DataInput):
-            return bool(data_config.api_call)
-        if isinstance(data_config, dict):
-            return bool(data_config.get("api_call"))
-        return False
+        return isinstance(data_input.source, APIDataSource)
 
-    def _load_data_with_optional_api_debug(
-        self, data_config: Union[str, DataInput, Dict[str, Any]]
-    ) -> pd.DataFrame:
+    def _load_data_with_optional_api_debug(self, data_input: DataInput) -> pd.DataFrame:
         """Load data, capturing raw API results when debug mode is enabled."""
-        if not self._is_api_debug_enabled() or not self._is_api_data_config(
-            data_config
-        ):
-            return load_data_from_config(data_config, self.mapping)
+        if not self._is_api_debug_enabled() or not self._is_api_data_input(data_input):
+            return load_data_from_config(data_input, self.mapping)
 
-        if isinstance(data_config, DataInput):
-            bearer_token = _resolve_api_bearer_token(
-                api_bearer_token=data_config.api_bearer_token,
-                api_bearer_token_env=data_config.api_bearer_token_env,
-            )
-            raw_df, debug_info = load_data_from_api_with_debug(
-                data_config.api_call,
-                bearer_token=bearer_token,
-                custom_headers=data_config.api_headers,
-            )
-        else:
-            bearer_token = _resolve_api_bearer_token(
-                api_bearer_token=data_config.get("api_bearer_token"),
-                api_bearer_token_env=data_config.get("api_bearer_token_env"),
-            )
-            raw_df, debug_info = load_data_from_api_with_debug(
-                data_config["api_call"],
-                bearer_token=bearer_token,
-                custom_headers=data_config.get("api_headers"),
-            )
+        source = data_input.source
+        if not isinstance(source, APIDataSource):
+            return load_data_from_config(data_input, self.mapping)
+
+        bearer_token = _resolve_api_bearer_token(
+            api_bearer_token=source.bearer_token,
+        )
+        raw_df, debug_info = load_data_from_api_with_debug(
+            source.call,
+            bearer_token=bearer_token,
+            custom_headers=source.headers,
+        )
 
         self.api_debug_info = debug_info
         prepared_df = prepare_loaded_data_frame(raw_df, self.mapping)
@@ -287,21 +267,21 @@ class QCDashboard:
             inp = config.app.input
             # Update mapping, rules, tests to absolute paths in defaults dir
             if not os.path.exists(inp.mapping):
-                inp.mapping = str(defaults_dir / Path(inp.mapping).name)
+                inp.mapping = defaults_dir / Path(inp.mapping).name
             if not os.path.exists(inp.qc_rules):
-                inp.qc_rules = str(defaults_dir / Path(inp.qc_rules).name)
+                inp.qc_rules = defaults_dir / Path(inp.qc_rules).name
             if not os.path.exists(inp.qc_tests):
-                inp.qc_tests = str(defaults_dir / Path(inp.qc_tests).name)
+                inp.qc_tests = defaults_dir / Path(inp.qc_tests).name
 
         if config.qc and config.qc.input:
             inp = config.qc.input
             # Update mapping, rules, tests to absolute paths in defaults dir
             if not os.path.exists(inp.mapping):
-                inp.mapping = str(defaults_dir / Path(inp.mapping).name)
+                inp.mapping = defaults_dir / Path(inp.mapping).name
             if not os.path.exists(inp.qc_rules):
-                inp.qc_rules = str(defaults_dir / Path(inp.qc_rules).name)
+                inp.qc_rules = defaults_dir / Path(inp.qc_rules).name
             if not os.path.exists(inp.qc_tests):
-                inp.qc_tests = str(defaults_dir / Path(inp.qc_tests).name)
+                inp.qc_tests = defaults_dir / Path(inp.qc_tests).name
 
         return config
 
@@ -397,18 +377,13 @@ class QCDashboard:
             # Load processed QC results - check if API or file
             data_config = self.config.app.input.data
 
-            # Check if data source is configured (file or api_call)
-            has_configured_source = False
-            if isinstance(data_config, DataInput):
-                if data_config.file or data_config.api_call:
-                    has_configured_source = True
-            elif isinstance(data_config, dict):
-                if data_config.get("file") or data_config.get("api_call"):
-                    has_configured_source = True
-            elif isinstance(data_config, str) and data_config:
+            try:
+                data_config = self._resolve_data_config_for_runtime(data_config)
                 has_configured_source = True
-
-            data_config = self._resolve_data_config_for_runtime(data_config)
+            except ConfigError as e:
+                if "must specify either 'file' or 'api_call'" not in str(e):
+                    raise
+                has_configured_source = False
 
             # Only attempt to load if a source is configured
             if has_configured_source:
@@ -2310,18 +2285,15 @@ class QCDashboard:
                     and self.config.app.input.data
                 ):
                     data_config = self.config.app.input.data
-                    if isinstance(data_config, DataInput):
-                        if data_config.api_call:
-                            source_desc = f"API: {data_config.api_call}"
-                        elif data_config.file:
-                            source_desc = f"File: {data_config.file}"
-                    elif isinstance(data_config, dict):
-                        if data_config.get("api_call"):
-                            source_desc = f"API: {data_config['api_call']}"
-                        elif data_config.get("file"):
-                            source_desc = f"File: {data_config['file']}"
-                    elif isinstance(data_config, str):
-                        source_desc = f"File: {data_config}"
+                    try:
+                        data_input = self._resolve_data_config_for_runtime(data_config)
+                        source = data_input.source
+                        if isinstance(source, APIDataSource):
+                            source_desc = f"API: {source.call}"
+                        elif isinstance(source, TSVDataSource):
+                            source_desc = f"File: {source.path}"
+                    except ConfigError:
+                        source_desc = "Unknown"
 
                 if not self.data.empty:
                     source_info_placeholder = st.empty()

--- a/src/uQCme/cli/main.py
+++ b/src/uQCme/cli/main.py
@@ -8,6 +8,8 @@ configurable quality control rules and tests.
 
 import argparse
 import sys
+
+from uQCme.core.config import RawDataInput
 from uQCme.core.engine import QCProcessor
 from uQCme.core.exceptions import UQCMeError
 
@@ -49,13 +51,13 @@ def main():
         # Prepare data override if arguments are provided
         data_override = None
         if args.file:
-            data_override = {"file": args.file}
+            data_override = RawDataInput(file=args.file)
         elif args.api_call:
-            data_override = {"api_call": args.api_call}
-            if args.api_bearer_token:
-                data_override["api_bearer_token"] = args.api_bearer_token
-            if args.api_bearer_token_env:
-                data_override["api_bearer_token_env"] = args.api_bearer_token_env
+            data_override = RawDataInput(
+                api_call=args.api_call,
+                api_bearer_token=args.api_bearer_token,
+                api_bearer_token_env=args.api_bearer_token_env,
+            )
 
         # Initialize processor with optional override
         processor = QCProcessor(args.config, data_override=data_override)

--- a/src/uQCme/core/config.py
+++ b/src/uQCme/core/config.py
@@ -1,28 +1,131 @@
-from typing import Dict, List, Optional, Union, Any
-from pydantic import BaseModel, Field, field_validator
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional, Union
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from uQCme.core.exceptions import ConfigError
 
 
-class DataInput(BaseModel):
+# YAML-facing data input shape. Not validated, hence raw
+class RawDataInput(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
     file: Optional[str] = None
     api_call: Optional[str] = None
-    api_query_params: Optional[Union[List[str], Dict[str, str]]] = None
+    api_query_params: Optional[Union[list[str], dict[str, str]]] = None
     api_bearer_token: Optional[str] = None
     api_bearer_token_env: Optional[str] = None
-    api_headers: Optional[Dict[str, str]] = None
+    api_headers: Optional[dict[str, str]] = None
 
 
+# Data comes from a local file path, not from an API.
+@dataclass(frozen=True)
+class TSVDataSource:
+    path: Path
+
+
+# Data comes from an API, not from a local file
+@dataclass(frozen=True)
+class APIDataSource:
+    # Base API URL to request e.g. "https://example.org/api/data?a=123"
+    call: str
+    # Replace any query params in call, such as `a=123` based on the following:
+    # * If None, replace nothing
+    # * If a list, pick those keys in the dashboard URL, and insert/replace them into
+    #   `call` to create the resulting URL
+    # * If a dict e.g. {"a": "x", "b": "y"} then take key "a" from dashboard and
+    #   add its value to `call` under the key "x".
+    query_params: Optional[Union[list[str], dict[str, str]]] = None
+    # A bearer token is essentially a password
+    bearer_token: Optional[str] = None
+    # Pass these as additional HTTP request headers - except "X-Project-Id", which is
+    # renamed to `project_id` (for backwards compat, TODO: Remove this edge case)
+    headers: Optional[dict[str, str]] = None
+
+
+# Validated runtime data input with exactly one source
+@dataclass(frozen=True)
+class DataInput:
+    source: Union[TSVDataSource, APIDataSource]
+
+
+def _normalize_bearer_token(raw: RawDataInput) -> Optional[str]:
+    has_literal = raw.api_bearer_token is not None
+    has_env = raw.api_bearer_token_env is not None
+
+    if has_literal and has_env:
+        raise ConfigError(
+            "API data input cannot specify both 'api_bearer_token' "
+            "and 'api_bearer_token_env'"
+        )
+    if has_literal:
+        return str(raw.api_bearer_token)
+    if has_env:
+        env_var = str(raw.api_bearer_token_env)
+        token = os.environ.get(env_var)
+        if token:
+            return token
+        raise ConfigError(
+            f"Environment variable '{env_var}' is not set, "
+            "but it is required for API bearer token authentication."
+        )
+    return None
+
+
+def normalize_data_input(raw: RawDataInput) -> DataInput:
+    """Convert raw YAML/legacy data config into the runtime representation."""
+    has_file = raw.file is not None
+    has_api = raw.api_call is not None
+
+    if has_file and has_api:
+        raise ConfigError("Data input cannot specify both 'file' and 'api_call'")
+    if not has_file and not has_api:
+        raise ConfigError("Data input must specify either 'file' or 'api_call'")
+
+    if has_file:
+        api_fields = {
+            "api_query_params": raw.api_query_params,
+            "api_bearer_token": raw.api_bearer_token,
+            "api_bearer_token_env": raw.api_bearer_token_env,
+            "api_headers": raw.api_headers,
+        }
+        present_api_fields = [
+            name for name, value in api_fields.items() if value is not None
+        ]
+        if present_api_fields:
+            joined_fields = ", ".join(present_api_fields)
+            raise ConfigError(
+                f"File data input cannot include API-only fields: {joined_fields}"
+            )
+        return DataInput(source=TSVDataSource(path=Path(str(raw.file))))
+
+    return DataInput(
+        source=APIDataSource(
+            call=str(raw.api_call),
+            query_params=raw.api_query_params,
+            bearer_token=_normalize_bearer_token(raw),
+            headers=raw.api_headers or None,
+        )
+    )
+
+
+# Input bundle for a QC processing run; not just one QC rule
 class QCInput(BaseModel):
-    data: Union[str, DataInput, Dict[str, Any]] = Field(default_factory=DataInput)
-    mapping: str
-    qc_rules: str
-    qc_tests: str
+    data: RawDataInput
+    mapping: Path
+    qc_rules: Path
+    qc_tests: Path
 
 
+# Output bundle for a QC processing run; not just one QC rule
 class QCOutput(BaseModel):
-    results: str = "qc_results.tsv"
-    warnings: str = "qc_warnings.tsv"
+    results: Path = Path("qc_results.tsv")
+    warnings: Path = Path("qc_warnings.tsv")
 
 
+# Overall config for QC run
 class QCConfig(BaseModel):
     input: QCInput
     output: QCOutput
@@ -34,10 +137,10 @@ class AppServer(BaseModel):
 
 
 class AppInput(BaseModel):
-    data: Union[str, DataInput, Dict[str, Any]] = Field(default_factory=DataInput)
-    mapping: str
-    qc_rules: str
-    qc_tests: str
+    data: RawDataInput
+    mapping: Path
+    qc_rules: Path
+    qc_tests: Path
     warnings: Optional[str] = None
 
 
@@ -53,7 +156,7 @@ class SampleApiAction(BaseModel):
     send_as_list: bool = True
     include_sample_ids: bool = False
     sample_ids_field: str = "sample_ids"
-    headers: Optional[Dict[str, str]] = None
+    headers: Optional[dict[str, str]] = None
 
     @field_validator("method", mode="before")
     @classmethod
@@ -70,8 +173,8 @@ class SampleApiAction(BaseModel):
 
 class ReportModeConfig(BaseModel):
     enabled: bool = False
-    default_visible_sections: Dict[str, bool] = Field(default_factory=dict)
-    default_filters: Dict[str, Any] = Field(default_factory=dict)
+    default_visible_sections: dict[str, bool] = Field(default_factory=dict)
+    default_filters: dict[str, Any] = Field(default_factory=dict)
 
 
 class DashboardConfig(BaseModel):
@@ -80,19 +183,19 @@ class DashboardConfig(BaseModel):
     table_height: int = Field(default=3600, ge=200)
     debug_api: bool = False
     report_mode: ReportModeConfig = Field(default_factory=ReportModeConfig)
-    sample_api_actions: List[SampleApiAction] = Field(default_factory=list)
+    sample_api_actions: list[SampleApiAction] = Field(default_factory=list)
 
 
 class AppConfig(BaseModel):
     server: AppServer = Field(default_factory=AppServer)
     input: AppInput
     dashboard: DashboardConfig = Field(default_factory=DashboardConfig)
-    ui_styling: Optional[Dict[str, Any]] = None
-    priority_colors: Optional[Dict[Union[int, str], Any]] = None
+    ui_styling: Optional[dict[str, Any]] = None
+    priority_colors: Optional[dict[Union[int, str], Any]] = None
 
 
 class LogConfig(BaseModel):
-    file: str = "uqcme.log"
+    file: Path = Path("uqcme.log")
 
 
 class UQCMeConfig(BaseModel):
@@ -101,7 +204,7 @@ class UQCMeConfig(BaseModel):
     qc: Optional[QCConfig] = None
     app: Optional[AppConfig] = None
     log: LogConfig = Field(default_factory=LogConfig)
-    outcome_priorities: Optional[Dict[str, int]] = None
+    outcome_priorities: Optional[dict[str, int]] = None
 
     @field_validator("qc", "app", mode="before")
     @classmethod

--- a/src/uQCme/core/engine.py
+++ b/src/uQCme/core/engine.py
@@ -14,7 +14,14 @@ from .loader import (
     load_config_from_file,
     validate_run_data_frame,
 )
-from .config import UQCMeConfig, DataInput, QCConfig
+from .config import (
+    APIDataSource,
+    DataInput,
+    QCConfig,
+    RawDataInput,
+    UQCMeConfig,
+    normalize_data_input,
+)
 from .exceptions import ConfigError, DataLoadError, ProcessingError, ValidationError
 from .logging import setup_logging
 from .schemas import QCRulesSchema, QCTestsSchema
@@ -28,7 +35,7 @@ class QCProcessor:
     def __init__(
         self,
         config_path: Optional[str] = None,
-        data_override: Optional[Dict[str, Any]] = None,
+        data_override: Optional[RawDataInput] = None,
     ):
         """Initialize the QC processor with configuration."""
         self.config = self._load_config(config_path)
@@ -41,20 +48,21 @@ class QCProcessor:
             # Merge with existing data config so auth-related settings are
             # preserved unless explicitly overridden.
             existing_data_config = self.config.qc.input.data
-            if isinstance(existing_data_config, DataInput):
-                merged_override = {
-                    **existing_data_config.model_dump(exclude_none=True),
-                    **data_override,
-                }
-            elif isinstance(existing_data_config, dict):
-                merged_override = {**existing_data_config, **data_override}
-            elif isinstance(existing_data_config, str):
-                merged_override = {"file": existing_data_config, **data_override}
+            override_raw = data_override.model_dump(exclude_none=True)
+            if data_override.file is not None:
+                merged_override = override_raw
             else:
-                merged_override = data_override
+                existing_raw = self._data_config_to_raw_dict(existing_data_config)
+                merged_override = {**existing_raw, **override_raw}
+                merged_override.pop("file", None)
+                if data_override.api_bearer_token is not None:
+                    merged_override.pop("api_bearer_token_env", None)
+                if data_override.api_bearer_token_env is not None:
+                    merged_override.pop("api_bearer_token", None)
 
-            # Convert override dict to DataInput model
-            self.config.qc.input.data = DataInput(**merged_override)
+            self.config.qc.input.data = normalize_data_input(
+                RawDataInput(**merged_override)
+            )
             logger.info(f"Data source overridden: {data_override}")
 
         self.logger = setup_logging(str(self.config.log.file))
@@ -66,6 +74,23 @@ class QCProcessor:
         self.results: pd.DataFrame = pd.DataFrame()
         self.warnings: set = set()  # Collect unique warnings
         self.skipped_rules: set = set()  # Collect unique skipped rules
+
+    def _data_config_to_raw_dict(self, data_config: Any) -> Dict[str, Any]:
+        """Return old YAML-shaped data config for API override merging."""
+        if isinstance(data_config, RawDataInput):
+            return data_config.model_dump(exclude_none=True)
+        if isinstance(data_config, DataInput):
+            source = data_config.source
+            if isinstance(source, APIDataSource):
+                raw_config = {
+                    "api_call": source.call,
+                    "api_query_params": source.query_params,
+                    "api_bearer_token": source.bearer_token,
+                    "api_headers": source.headers,
+                }
+                return raw_config
+            return {"file": str(source.path)}
+        return {}
 
     @property
     def qc_config(self) -> QCConfig:
@@ -105,11 +130,11 @@ class QCProcessor:
             inp = config.qc.input
             # Update mapping, rules, tests to absolute paths in defaults dir
             if not Path(inp.mapping).exists():
-                inp.mapping = str(defaults_dir / Path(inp.mapping).name)
+                inp.mapping = defaults_dir / Path(inp.mapping).name
             if not Path(inp.qc_rules).exists():
-                inp.qc_rules = str(defaults_dir / Path(inp.qc_rules).name)
+                inp.qc_rules = defaults_dir / Path(inp.qc_rules).name
             if not Path(inp.qc_tests).exists():
-                inp.qc_tests = str(defaults_dir / Path(inp.qc_tests).name)
+                inp.qc_tests = defaults_dir / Path(inp.qc_tests).name
 
         return config
 
@@ -124,9 +149,11 @@ class QCProcessor:
 
     def load_run_data(self):
         """Load run data from configuration."""
-        data_config = self.qc_config.input.data
+        data_input = self.qc_config.input.data
+        if not isinstance(data_input, DataInput):
+            data_input = normalize_data_input(data_input)
         # Pass mapping config for column name normalization
-        self.run_data = load_data_from_config(data_config, self.mapping)
+        self.run_data = load_data_from_config(data_input, self.mapping)
         self.run_data = self.prepare_run_data(self.run_data, validate_schema=False)
         self.logger.info("✓ Run data loaded: %d samples", len(self.run_data))
 

--- a/src/uQCme/core/loader.py
+++ b/src/uQCme/core/loader.py
@@ -1,16 +1,23 @@
 """Data loading utilities for uQCme."""
 
 import copy
+import logging
 import os
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
 import pandas as pd
 import requests
 import urllib3
 import yaml
-from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
-from typing import Union, Dict, Any, Optional, List, Tuple
-import logging
 from pandera.errors import SchemaError
-from .config import UQCMeConfig, DataInput
+
+from .config import (
+    APIDataSource,
+    DataInput,
+    TSVDataSource,
+    UQCMeConfig,
+)
 from .exceptions import ConfigError, DataLoadError, ValidationError
 from .schemas import RunDataSchema
 
@@ -94,7 +101,8 @@ def _resolve_project_scope_request(
 
 
 def _resolve_api_bearer_token(
-    api_bearer_token: Optional[str] = None, api_bearer_token_env: Optional[str] = None
+    api_bearer_token: Optional[str] = None,
+    api_bearer_token_env: Optional[str] = None,
 ) -> Optional[str]:
     """Resolve bearer token from explicit config value or environment."""
     if api_bearer_token:
@@ -548,15 +556,14 @@ def load_config_from_file(config_path: str) -> UQCMeConfig:
 
 
 def load_data_from_config(
-    data_config: Union[str, Dict[str, Any], DataInput],
+    data_input: DataInput,
     mapping_config: Optional[Dict[str, Any]] = None,
 ) -> pd.DataFrame:
     """
     Load data from a file or API based on configuration.
 
     Args:
-        data_config: Configuration for data source. Can be a string
-                    (file path), a dictionary, or a DataInput model.
+        data_input: Normalized runtime data source.
         mapping_config: Optional mapping configuration that defines
                        column name mappings (e.g., QC.mapping -> sample_name).
 
@@ -568,51 +575,21 @@ def load_data_from_config(
         DataLoadError: If data cannot be loaded.
     """
     try:
-        df = None
-        if isinstance(data_config, DataInput):
-            if data_config.api_call:
-                bearer_token = _resolve_api_bearer_token(
-                    api_bearer_token=data_config.api_bearer_token,
-                    api_bearer_token_env=data_config.api_bearer_token_env,
-                )
-                df = load_data_from_api(
-                    data_config.api_call,
-                    bearer_token=bearer_token,
-                    custom_headers=data_config.api_headers,
-                )
-            elif data_config.file:
-                df = pd.read_csv(data_config.file, sep="\t")
-            else:
-                # If both are None, check if it was initialized empty
-                # For now, raise error if neither is set
-                error_msg = "Either 'file' or 'api_call' must be specified"
-                raise ConfigError(error_msg)
+        source = data_input.source
 
-        elif isinstance(data_config, dict):
-            # New structure with file/api_call options
-            if data_config.get("api_call"):
-                # Load data from API
-                api_url = data_config["api_call"]
-                bearer_token = _resolve_api_bearer_token(
-                    api_bearer_token=data_config.get("api_bearer_token"),
-                    api_bearer_token_env=data_config.get("api_bearer_token_env"),
-                )
-                df = load_data_from_api(
-                    api_url,
-                    bearer_token=bearer_token,
-                    custom_headers=data_config.get("api_headers"),
-                )
-            elif data_config.get("file"):
-                # Load data from file
-                df = pd.read_csv(data_config["file"], sep="\t")
-            else:
-                error_msg = (
-                    "Either 'file' or 'api_call' must be specified for data input"
-                )
-                raise ConfigError(error_msg)
+        if isinstance(source, APIDataSource):
+            bearer_token = _resolve_api_bearer_token(
+                api_bearer_token=source.bearer_token,
+            )
+            df = load_data_from_api(
+                source.call,
+                bearer_token=bearer_token,
+                custom_headers=source.headers,
+            )
+        elif isinstance(source, TSVDataSource):
+            df = pd.read_csv(source.path, sep="\t")
         else:
-            # Legacy structure - direct file path
-            df = pd.read_csv(data_config, sep="\t")
+            raise ConfigError(f"Unsupported data source type: {type(source)!r}")
 
         df = prepare_loaded_data_frame(df, mapping_config)
 

--- a/src/uQCme/defaults/config.yaml
+++ b/src/uQCme/defaults/config.yaml
@@ -3,12 +3,7 @@ version: "0.9.2"
 
 qc:
   input:
-    data:
-      file: ""
-      api_call: ""
-      api_bearer_token: ""
-      api_bearer_token_env: ""
-      api_headers: {}
+    data: {}
     mapping: "mapping.yaml"
     qc_rules: "QC_rules.tsv"
     qc_tests: "QC_tests.tsv"
@@ -23,10 +18,6 @@ app:
   input:
     data:
       file: "qc_results.tsv"
-      api_call: ""
-      api_bearer_token: ""
-      api_bearer_token_env: ""
-      api_headers: {}
     mapping: "mapping.yaml"
     qc_rules: "QC_rules.tsv"
     qc_tests: "QC_tests.tsv"

--- a/tests/fixtures/config_example.yaml
+++ b/tests/fixtures/config_example.yaml
@@ -3,7 +3,8 @@ version: "0.9.2"
 
 qc:
   input:
-    data: "./tests/data/example_run_data.tsv"
+    data:
+      file: "./tests/data/example_run_data.tsv"
     mapping: "./tests/data/mapping.yaml"
     qc_rules: "./tests/data/QC_rules.tsv"
     qc_tests: "./tests/data/QC_tests.tsv"
@@ -15,7 +16,8 @@ app:
     host: "127.0.0.1"
     port: 3838
   input:
-    data: "./tests/uQCme_example_run_data.tsv"
+    data:
+      file: "./tests/uQCme_example_run_data.tsv"
     mapping: "./tests/data/mapping.yaml"
     qc_rules: "./tests/data/QC_rules.tsv"
     qc_tests: "./tests/data/QC_tests.tsv"

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -4,13 +4,21 @@
 import sys
 import unittest
 from pathlib import Path
+from unittest.mock import patch
 
 from pydantic import ValidationError
 
 # Add src directory to import path.
 sys.path.insert(0, str(Path(__file__).parents[2] / "src"))
 
-from uQCme.core.config import UQCMeConfig
+from uQCme.core.config import (
+    APIDataSource,
+    RawDataInput,
+    TSVDataSource,
+    UQCMeConfig,
+    normalize_data_input,
+)
+from uQCme.core.exceptions import ConfigError
 
 
 class TestConfigModels(unittest.TestCase):
@@ -21,7 +29,7 @@ class TestConfigModels(unittest.TestCase):
         config = UQCMeConfig(
             app={
                 "input": {
-                    "data": {"file": "output/qc_results.tsv"},
+                    "data": RawDataInput(file="output/qc_results.tsv"),
                     "mapping": "config/mapping.yaml",
                     "qc_rules": "config/QC_rules.tsv",
                     "qc_tests": "config/QC_tests.tsv",
@@ -48,7 +56,7 @@ class TestConfigModels(unittest.TestCase):
             UQCMeConfig(
                 app={
                     "input": {
-                        "data": {"file": "output/qc_results.tsv"},
+                        "data": RawDataInput(file="output/qc_results.tsv"),
                         "mapping": "config/mapping.yaml",
                         "qc_rules": "config/QC_rules.tsv",
                         "qc_tests": "config/QC_tests.tsv",
@@ -71,7 +79,7 @@ class TestConfigModels(unittest.TestCase):
         config = UQCMeConfig(
             app={
                 "input": {
-                    "data": {"file": "output/qc_results.tsv"},
+                    "data": RawDataInput(file="output/qc_results.tsv"),
                     "mapping": "config/mapping.yaml",
                     "qc_rules": "config/QC_rules.tsv",
                     "qc_tests": "config/QC_tests.tsv",
@@ -100,7 +108,7 @@ class TestConfigModels(unittest.TestCase):
     def test_dashboard_table_height_defaults_and_overrides(self):
         """Dashboard table height should default to a 100-row viewport."""
         base_input = {
-            "data": {"file": "output/qc_results.tsv"},
+            "data": RawDataInput(file="output/qc_results.tsv"),
             "mapping": "config/mapping.yaml",
             "qc_rules": "config/QC_rules.tsv",
             "qc_tests": "config/QC_tests.tsv",
@@ -116,6 +124,37 @@ class TestConfigModels(unittest.TestCase):
 
         self.assertEqual(default_config.app.dashboard.table_height, 3600)
         self.assertEqual(custom_config.app.dashboard.table_height, 4200)
+
+    def test_qc_output_paths_are_path_objects(self):
+        """QC input and output file paths should parse to Path instances."""
+        config = UQCMeConfig(
+            qc={
+                "input": {
+                    "data": RawDataInput(file="input/run_data.tsv"),
+                    "mapping": "config/mapping.yaml",
+                    "qc_rules": "config/QC_rules.tsv",
+                    "qc_tests": "config/QC_tests.tsv",
+                },
+                "output": {
+                    "results": "output/qc_results.tsv",
+                    "warnings": "output/qc_warnings.tsv",
+                },
+            }
+        )
+
+        self.assertEqual(config.qc.input.mapping, Path("config/mapping.yaml"))
+        self.assertEqual(config.qc.input.qc_rules, Path("config/QC_rules.tsv"))
+        self.assertEqual(config.qc.input.qc_tests, Path("config/QC_tests.tsv"))
+        self.assertEqual(config.qc.output.results, Path("output/qc_results.tsv"))
+        self.assertEqual(config.qc.output.warnings, Path("output/qc_warnings.tsv"))
+
+    def test_log_file_is_path_object(self):
+        """Log file paths should parse to Path instances."""
+        default_config = UQCMeConfig()
+        custom_config = UQCMeConfig(log={"file": "logs/uqcme.log"})
+
+        self.assertEqual(default_config.log.file, Path("uqcme.log"))
+        self.assertEqual(custom_config.log.file, Path("logs/uqcme.log"))
 
     def test_data_input_supports_api_bearer_token_fields(self):
         """Data input config should parse bearer token auth fields."""
@@ -140,12 +179,147 @@ class TestConfigModels(unittest.TestCase):
         self.assertEqual(data_input.api_bearer_token_env, "UQCME_API_TOKEN")
         self.assertEqual(data_input.api_headers["X-Project-Id"], "project-123")
 
+    def test_data_input_config_loads_raw_yaml_shape(self):
+        """Config parsing keeps the boundary data input shape unvalidated."""
+        config = UQCMeConfig(
+            app={
+                "input": {
+                    "data": {
+                        "file": "output/qc_results.tsv",
+                        "api_call": "https://example.org/api/data",
+                    },
+                    "mapping": "config/mapping.yaml",
+                    "qc_rules": "config/QC_rules.tsv",
+                    "qc_tests": "config/QC_tests.tsv",
+                }
+            }
+        )
+
+        self.assertIsInstance(config.app.input.data, RawDataInput)
+        self.assertEqual(config.app.input.data.file, "output/qc_results.tsv")
+        self.assertEqual(
+            config.app.input.data.api_call,
+            "https://example.org/api/data",
+        )
+
+    def test_data_input_config_rejects_unknown_fields(self):
+        """Unknown structured data input fields should fail config parsing."""
+        with self.assertRaises(ValidationError):
+            UQCMeConfig(
+                app={
+                    "input": {
+                        "data": {
+                            "file": "output/qc_results.tsv",
+                            "typo": "unexpected",
+                        },
+                        "mapping": "config/mapping.yaml",
+                        "qc_rules": "config/QC_rules.tsv",
+                        "qc_tests": "config/QC_tests.tsv",
+                    }
+                }
+            )
+
+    def test_data_input_config_rejects_scalar_path(self):
+        """Data input must use the structured YAML shape."""
+        with self.assertRaises(ValidationError):
+            UQCMeConfig(
+                app={
+                    "input": {
+                        "data": "output/qc_results.tsv",
+                        "mapping": "config/mapping.yaml",
+                        "qc_rules": "config/QC_rules.tsv",
+                        "qc_tests": "config/QC_tests.tsv",
+                    }
+                }
+            )
+
+    def test_normalize_data_input_builds_file_source(self):
+        """Raw file config converts to the runtime file data source."""
+        data_input = normalize_data_input(RawDataInput(file="output/qc_results.tsv"))
+
+        self.assertIsInstance(data_input.source, TSVDataSource)
+        self.assertEqual(data_input.source.path, Path("output/qc_results.tsv"))
+
+    def test_normalize_data_input_treats_empty_string_as_present(self):
+        """An explicit empty string is a configured value, not absence."""
+        data_input = normalize_data_input(RawDataInput(file=""))
+
+        self.assertIsInstance(data_input.source, TSVDataSource)
+        self.assertEqual(data_input.source.path, Path(""))
+
+    def test_normalize_data_input_builds_api_source(self):
+        """Raw API config converts to the runtime API data source."""
+        with patch.dict("os.environ", {"UQCME_API_TOKEN": "token-from-env"}):
+            data_input = normalize_data_input(
+                RawDataInput(
+                    api_call="https://example.org/api/data",
+                    api_bearer_token_env="UQCME_API_TOKEN",
+                )
+            )
+
+        self.assertIsInstance(data_input.source, APIDataSource)
+        self.assertEqual(data_input.source.call, "https://example.org/api/data")
+        self.assertEqual(data_input.source.bearer_token, "token-from-env")
+
+    def test_normalize_data_input_builds_bearer_token(self):
+        """Raw API bearer token stays a resolved runtime token."""
+        data_input = normalize_data_input(
+            RawDataInput(
+                api_call="https://example.org/api/data",
+                api_bearer_token="test-token",
+            )
+        )
+
+        self.assertIsInstance(data_input.source, APIDataSource)
+        self.assertEqual(data_input.source.bearer_token, "test-token")
+
+    def test_normalize_data_input_rejects_missing_bearer_token_env(self):
+        """API bearer token env vars are resolved at normalization time."""
+        with patch.dict("os.environ", {}, clear=True):
+            with self.assertRaisesRegex(
+                ConfigError,
+                "Environment variable 'UQCME_API_TOKEN' is not set",
+            ):
+                normalize_data_input(
+                    RawDataInput(
+                        api_call="https://example.org/api/data",
+                        api_bearer_token_env="UQCME_API_TOKEN",
+                    )
+                )
+
+    def test_normalize_data_input_rejects_two_bearer_token_sources(self):
+        """Runtime API auth cannot use both literal and env bearer tokens."""
+        with self.assertRaisesRegex(
+            ConfigError,
+            "cannot specify both 'api_bearer_token' and 'api_bearer_token_env'",
+        ):
+            normalize_data_input(
+                RawDataInput(
+                    api_call="https://example.org/api/data",
+                    api_bearer_token="test-token",
+                    api_bearer_token_env="UQCME_API_TOKEN",
+                )
+            )
+
+    def test_normalize_data_input_rejects_file_and_api(self):
+        """Runtime data input cannot represent both file and API sources."""
+        with self.assertRaisesRegex(
+            ConfigError,
+            "cannot specify both 'file' and 'api_call'",
+        ):
+            normalize_data_input(
+                RawDataInput(
+                    file="output/qc_results.tsv",
+                    api_call="https://example.org/api/data",
+                )
+            )
+
     def test_sample_api_action_supports_bearer_token_fields(self):
         """Sample API actions should parse bearer token auth fields."""
         config = UQCMeConfig(
             app={
                 "input": {
-                    "data": {"file": "output/qc_results.tsv"},
+                    "data": RawDataInput(file="output/qc_results.tsv"),
                     "mapping": "config/mapping.yaml",
                     "qc_rules": "config/QC_rules.tsv",
                     "qc_tests": "config/QC_tests.tsv",

--- a/tests/unit/test_dashboard.py
+++ b/tests/unit/test_dashboard.py
@@ -254,7 +254,7 @@ sys.modules["uQCme.plot"] = plot_stub
 # that happens
 from uQCme import app  # noqa: E402
 from uQCme.core import loader  # noqa: E402
-from uQCme.core.config import UQCMeConfig  # noqa: E402
+from uQCme.core.config import RawDataInput, UQCMeConfig  # noqa: E402
 
 dashboard_main = importlib.import_module("uQCme.app.main")
 
@@ -338,7 +338,7 @@ def _bare_dashboard(table_height: int = 3600):
     dashboard.config = UQCMeConfig(
         app={
             "input": {
-                "data": {"file": "output/qc_results.tsv"},
+                "data": RawDataInput(file="output/qc_results.tsv"),
                 "mapping": "config/mapping.yaml",
                 "qc_rules": "config/QC_rules.tsv",
                 "qc_tests": "config/QC_tests.tsv",


### PR DESCRIPTION
The config had a lot of looseness with types and weak typing, which made intent difficult.
This is a WORK IN PROGRESS PR to improve the situation. It's breaking because it places stricter requirements on the config.

Among the many changes are:
* key: "" is no longer interpreted as the absence of a value
* Several config values had default values which were invalid and caused runtime errors
* Several config used to have many ways to specify the same thing. For example, `data` could be a `str` meaning the path to a yaml with the content or a fully specified config (i.e a typed dict, essentially the content of the yaml) or an arbitrary dict. The bearer token could be an env variable, a literal, or both, or neither. Now this is cleaned up
* More paths are now represented as Path